### PR TITLE
Added fetching rosdep dependencies in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ $ cd ~/ros2_ws/src
 $ git clone --recurse-submodules https://github.com/mgonzs13/ros2_asus_xtion
 $ sudo apt install ros-humble-depth-image-proc
 $ cd ~/ros2_ws
+$ rosdep install --from-paths . --ignore-src
 $ colcon build
 ```
 


### PR DESCRIPTION
Just to make it crystal clear that you to install the rosdep dependencies if you don't have them first before building.